### PR TITLE
ci: add explicit permissions to GHA workflows

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -2,6 +2,9 @@
 # See https://github.com/metanorma/cimas
 name: rake
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master, main ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@
 # See https://github.com/metanorma/cimas
 name: release
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -22,4 +27,3 @@ jobs:
     secrets:
       rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
-


### PR DESCRIPTION
Add `permissions` blocks to rake and release workflows following the pattern from metanorma/canon.

- **rake**: `contents: read`
- **release**: `contents: write`, `packages: write`, `id-token: write`