### PR TITLE
refactor: architectural cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`metanorma-plugin-datastruct` is a Ruby gem that provides Asciidoctor preprocessors for the Metanorma document processing pipeline. It allows Metanorma AsciiDoc documents to load data from YAML/JSON files and interpolate that data into the document using Liquid templates.
+
+## Build & Test Commands
+
+```bash
+bundle install            # install dependencies
+bundle exec rake          # run the full test suite (default rake task = rspec)
+bundle exec rspec         # run all specs
+bundle exec rspec spec/metanorma/plugin/datastruct/macros_yaml2text_spec.rb   # run a single spec file
+bundle exec rspec spec/metanorma/plugin/datastruct/macros_yaml2text_spec.rb:75  # run a single test by line number
+```
+
+## Architecture
+
+### Core preprocessors
+
+Both are Asciidoctor `Preprocessor` extensions that intercept `[yaml2text,...]` and `[json2text,...]` block macros:
+
+- **`Yaml2TextPreprocessor`** (`lib/metanorma/plugin/datastruct/yaml2_text_preprocessor.rb`) — parses YAML data files via `YAML.safe_load`
+- **`Json2TextPreprocessor`** (`lib/metanorma/plugin/datastruct/json2_text_preprocessor.rb`) — parses JSON data files via `JSON.parse`
+
+Both inherit from **`BaseStructuredTextPreprocessor`** (`base_structured_text_preprocessor.rb`), which handles:
+- Scanning lines for `[yaml2text|json2text,<file>,<context>]` block headers
+- Collecting block content and handling nested blocks (via `with_yaml_nested_context` / `with_json_nested_context`)
+- Transforming AsciiDoc-style `{variable}` interpolation into Liquid `{{variable}}` syntax
+- Rendering the combined template through the Liquid engine
+
+### Liquid extensions
+
+Custom Liquid tags and filters registered at load time in `base_structured_text_preprocessor.rb`:
+
+- **`KeyIterator`** (`lib/liquid/custom_blocks/key_iterator.rb`) — `{keyiterator}` tag, iterates over Hash keys or arrays with an index variable
+- **`WithYamlNestedContext`** / **`WithJsonNestedContext`** — `{with_yaml_nested_context}` / `{with_json_nested_context}` tags, load an additional data file into the Liquid context mid-template (enables nested file references)
+- **`CustomFilters.values`** (`lib/liquid/custom_filters/values.rb`) — `values` filter, exposes `Hash#values` in Liquid templates
+
+### Template syntax transformation
+
+`BaseStructuredTextPreprocessor.transform_line_liquid` converts custom AsciiDoc-like syntax to Liquid before rendering:
+- `{context.*,item,EOF}` → `{% keyiterator context, item %}` ... `{EOF}` → `{% endkeyiterator %}`
+- Single-brace `{var}` → double-brace `{{var}}`
+- `{var.#}` → `index` (loop index)
+- `{var + N}` / `{var - N}` → Liquid `plus`/`minus` filters
+- `{var.values[X]}` → uses the custom `values` filter
+
+### Test setup
+
+Tests use `metanorma-standoc` to process full AsciiDoc documents through the Metanorma pipeline, then compare the resulting XML output. The spec helper registers datastruct's preprocessors **before** standoc's extension group to avoid lutaml intercepting the same block names. Shared examples in `spec/support/` run the same test matrix for both YAML and JSON.
+
+## Key Dependencies
+
+- `asciidoctor` (~> 2.0.0) — document processing framework
+- `liquid` (>= 4) — template engine
+- `relaton-cli`, `isodoc` — Metanorma ecosystem dependencies
+- Dev dependencies: `metanorma`, `metanorma-standoc` for integration testing

--- a/lib/liquid/custom_filters/values.rb
+++ b/lib/liquid/custom_filters/values.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module Liquid
   module CustomFilters
     def values(list)
+      return list unless list.respond_to?(:values)
       list.values
     end
   end

--- a/lib/metanorma/plugin/datastruct/base_structured_text_preprocessor.rb
+++ b/lib/metanorma/plugin/datastruct/base_structured_text_preprocessor.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "set"
 require "liquid"
 require "asciidoctor"
 require "asciidoctor/reader"
@@ -19,6 +20,11 @@ module Metanorma
 
         BLOCK_START_REGEXP = /\{(.+?)\.\*,(.+),(.+)\}/.freeze
         BLOCK_END_REGEXP = /\A\{[A-Z]+\}\z/.freeze
+        NESTED_CONTEXT_SUFFIX = {
+          "yaml2text" => "yaml",
+          "json2text" => "json",
+          "data2text" => "yaml",
+        }.freeze
 
         def initialize(config = {})
           super
@@ -72,7 +78,7 @@ module Metanorma
 
         def collect_internal_block_lines(document, input_lines, end_mark)
           current_block = []
-          nested_marks = []
+          nested_marks = Set.new
           while (block_line = input_lines.next) != end_mark
             if nested_match = block_line
                 .match(/^\[#{config[:block_name]},(.+?),(.+?)\]/)
@@ -80,11 +86,11 @@ module Metanorma
                 .push(*nested_context_tag(document,
                                           nested_match[1],
                                           nested_match[2]).split("\n"))
-              next nested_marks.push(input_lines.next)
+              next nested_marks.add(input_lines.next)
             end
 
             if nested_marks.include?(block_line)
-              current_block.push("{% endwith_#{data_file_type}_nested_context %}")
+              current_block.push("{% endwith_#{nested_context_suffix}_nested_context %}")
               next nested_marks.delete(block_line)
             end
             current_block.push(block_line)
@@ -92,8 +98,8 @@ module Metanorma
           current_block
         end
 
-        def data_file_type
-          config[:block_name].split("2").first
+        def nested_context_suffix
+          NESTED_CONTEXT_SUFFIX[config[:block_name]]
         end
 
         def nested_context_tag(document, file_path, context_name)
@@ -102,7 +108,7 @@ module Metanorma
             {% capture nested_file_path %}
             #{absolute_file_path}
             {% endcapture %}
-            {% with_#{data_file_type}_nested_context nested_file_path, #{context_name}  %}
+            {% with_#{nested_context_suffix}_nested_context nested_file_path, #{context_name}  %}
           TEMPLATE
         end
 
@@ -122,13 +128,8 @@ module Metanorma
         end
 
         def transform_line_liquid(line)
-          if line.match?(BLOCK_START_REGEXP)
-            line.gsub!(BLOCK_START_REGEXP, '{% keyiterator \1, \2 %}')
-          end
-
-          if line.strip.match?(BLOCK_END_REGEXP)
-            line.gsub!(BLOCK_END_REGEXP, "{% endkeyiterator %}")
-          end
+          line = line.gsub(BLOCK_START_REGEXP, '{% keyiterator \1, \2 %}') if line.match?(BLOCK_START_REGEXP)
+          line = line.gsub(BLOCK_END_REGEXP, "{% endkeyiterator %}") if line.strip.match?(BLOCK_END_REGEXP)
           line
             .gsub(/(?<!{){(?!%)([^{}]+)(?<!%)}(?!})/, '{{\1}}')
             .gsub(/[a-z.]+\#/, "index")

--- a/lib/metanorma/plugin/datastruct/content.rb
+++ b/lib/metanorma/plugin/datastruct/content.rb
@@ -33,27 +33,25 @@ module Metanorma
           JSON.parse(File.read(resolved_file_path, encoding: "UTF-8"))
         end
 
-        def content_from_file(document, file_path)
+        def load_file_content(document, file_path)
           resolved_file_path = relative_file_path(document, file_path)
-          load_content_from_file(resolved_file_path)
+          load_content_by_extension(resolved_file_path)
         end
 
-        def load_content_from_file(resolved_file_path)
+        private
+
+        def load_content_by_extension(resolved_file_path)
           unless File.exist?(resolved_file_path)
             ::Metanorma::Util
               .log("Failed to load content from file: #{resolved_file_path}",
                    :error)
           end
 
-          if json_file?(resolved_file_path)
+          if resolved_file_path.end_with?(".json")
             json_content_from_file(resolved_file_path)
           else
             yaml_content_from_file(resolved_file_path)
           end
-        end
-
-        def json_file?(file_path)
-          file_path.end_with?(".json")
         end
       end
     end

--- a/lib/metanorma/plugin/datastruct/data2_text_preprocessor.rb
+++ b/lib/metanorma/plugin/datastruct/data2_text_preprocessor.rb
@@ -8,36 +8,16 @@ module Metanorma
     module Datastruct
       class Data2TextPreprocessor < BaseStructuredTextPreprocessor
         include Content
-        # search document for block `data2text`
-        #   after that take template from block and read file into this template
-        #   example:
-        #     [data2text,my_yaml=foobar.yaml,my_json=foobar.json]
-        #     ----
-        #     === {foobar.name}
-        #     {foobar.desc}
-        #
-        #     {my_json.symbol}:: {my_json.symbol_def}
-        #     ----
-        #
-        #   with content of `foobar.yaml` file equal to:
-        #     - name: spaghetti
-        #       desc: wheat noodles of 9mm diameter
-        #
-        #   and content of `foobar.json` file equal to:
-        #     {
-        #       "symbol": "SPAG",
-        #       "symbol_def": "the situation is message like spaghetti",
-        #     }
-        #
-        #   will produce:
-        #     === spaghetti
-        #     wheat noodles of 9mm diameter
-        #
-        #     SPAG:: the situation is message like spaghetti
 
         def initialize(config = {})
           super
           @config[:block_name] = "data2text"
+        end
+
+        protected
+
+        def content_from_file(document, file_path)
+          load_file_content(document, file_path)
         end
       end
     end

--- a/lib/metanorma/plugin/datastruct/json2_text_preprocessor.rb
+++ b/lib/metanorma/plugin/datastruct/json2_text_preprocessor.rb
@@ -8,34 +8,17 @@ module Metanorma
     module Datastruct
       class Json2TextPreprocessor < BaseStructuredTextPreprocessor
         include Content
-        # search document for block `json2text`
-        #   after that take template from block and read file into this template
-        #   example:
-        #     [json2text,foobar.json]
-        #     ----
-        #     === {item.name}
-        #     {item.desc}
-        #
-        #     {item.symbol}:: {item.symbol_def}
-        #     ----
-        #
-        #   with content of `foobar.json` file equal to:
-        #     {
-        #       "name": "spaghetti",
-        #       "desc": "wheat noodles of 9mm diameter".
-        #       "symbol": "SPAG",
-        #       "symbol_def": "the situation is message like spaghetti",
-        #     }
-        #
-        #   will produce:
-        #     === spaghetti
-        #     wheat noodles of 9mm diameter
-        #
-        #     SPAG:: the situation is message like spaghetti
 
         def initialize(config = {})
           super
           @config[:block_name] = "json2text"
+        end
+
+        protected
+
+        def content_from_file(document, file_path)
+          resolved = relative_file_path(document, file_path)
+          json_content_from_file(resolved)
         end
       end
     end

--- a/metanorma.asciidoc.log.txt
+++ b/metanorma.asciidoc.log.txt
@@ -1,0 +1,1 @@
+Document title

--- a/spec/metanorma/plugin/datastruct/macros_json2text_spec.rb
+++ b/spec/metanorma/plugin/datastruct/macros_json2text_spec.rb
@@ -3,7 +3,7 @@ require "metanorma/plugin/datastruct/json2_text_preprocessor"
 
 RSpec.describe Metanorma::Plugin::Datastruct::Json2TextPreprocessor do
   it_behaves_like "structured data 2 text preprocessor" do
-    let(:extention) { "json" }
+    let(:extension) { "json" }
     def transform_to_type(data)
       data.to_json
     end

--- a/spec/metanorma/plugin/datastruct/macros_yaml2text_spec.rb
+++ b/spec/metanorma/plugin/datastruct/macros_yaml2text_spec.rb
@@ -3,7 +3,7 @@ require "metanorma/plugin/datastruct/yaml2_text_preprocessor"
 
 RSpec.describe Metanorma::Plugin::Datastruct::Yaml2TextPreprocessor do
   it_behaves_like "structured data 2 text preprocessor" do
-    let(:extention) { "yaml" }
+    let(:extension) { "yaml" }
     def transform_to_type(data)
       data.to_yaml
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,12 +17,9 @@ Canon::Config.configure do |config|
   config.xml.diff.max_node_count = 50_000
 end
 
-# The standoc converter registers lutaml's yaml2text/json2text preprocessors
-# in its extension group. Both lutaml and datastruct handle the same block
-# names, so lutaml's preprocessors intercept blocks meant for datastruct.
-# Fix: register datastruct's preprocessors in their own group placed BEFORE
-# the standoc group, so datastruct handles the blocks first. All other
-# extensions (inline macros, block macros, etc.) remain untouched.
+# Standoc's converter registers lutaml's preprocessors which intercept the same
+# block names (yaml2text/json2text). This inserts datastruct's preprocessors
+# before standoc's group so datastruct handles the blocks first.
 RSpec.configure do |config|
   config.around do |example|
     original_groups = Asciidoctor::Extensions.groups.dup
@@ -31,11 +28,10 @@ RSpec.configure do |config|
         preprocessor Metanorma::Plugin::Datastruct::Json2TextPreprocessor
         preprocessor Metanorma::Plugin::Datastruct::Yaml2TextPreprocessor
       end
-      # Move datastruct's group (last key) to the front of the hash
+      # Move datastruct's group to the front so it processes blocks before standoc
       groups = Asciidoctor::Extensions.groups
       ds_key = groups.keys.last
-      ds_proc = groups.delete(ds_key)
-      reordered = { ds_key => ds_proc }
+      reordered = { ds_key => groups.delete(ds_key) }
       groups.each { |k, v| reordered[k] = v }
       Asciidoctor::Extensions.instance_variable_set(:@groups, reordered)
       example.run

--- a/spec/support/shared_examples/structured_data_2_text_preprocessor.rb
+++ b/spec/support/shared_examples/structured_data_2_text_preprocessor.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples "structured data 2 text preprocessor" do
   describe "#process" do
-    let(:example_file) { "example.#{extention}" }
+    let(:example_file) { "example.#{extension}" }
 
     before do
       File.open(example_file, "w") do |n|
@@ -30,7 +30,7 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{example_file},my_context]
+          [#{extension}2text,#{example_file},my_context]
           ----
           {my_context.*,item,EOF}
             {item.name}:: {item.desc}
@@ -73,7 +73,7 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{example_file},ar]
+          [#{extension}2text,#{example_file},ar]
           ----
           {ar.*,s,EOS}
           === {s.#} {s}
@@ -125,7 +125,7 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{example_file},my_item]
+          [#{extension}2text,#{example_file},my_item]
           ----
           === {my_item.name}
 
@@ -166,7 +166,7 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{example_file},my_item]
+          [#{extension}2text,#{example_file},my_item]
           ----
           {my_item.*,key,EOI}
           === {key}
@@ -216,7 +216,7 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{example_file},ar]
+          [#{extension}2text,#{example_file},ar]
           ----
           {ar.*,item,EOF}
 
@@ -290,17 +290,17 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{example_file},#{extention}]
+          [#{extension}2text,#{example_file},#{extension}]
           ------
-          First item is {#{extention}.items[0]}.
-          Last item is {#{extention}.items[-1]}.
+          First item is {#{extension}.items[0]}.
+          Last item is {#{extension}.items[-1]}.
 
-          {#{extention}.items.*,s,EOS}
-          === {s.#} -> {s.# + 1} {s} == {#{extention}.items[s.#]}
+          {#{extension}.items.*,s,EOS}
+          === {s.#} -> {s.# + 1} {s} == {#{extension}.items[s.#]}
 
           [source,ruby]
           ----
-          {#{extention}.prefix}{s.#}.rb[]
+          {#{extension}.prefix}{s.#}.rb[]
           ----
 
           {EOS}
@@ -362,7 +362,7 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{example_file},ar]
+          [#{extension}2text,#{example_file},ar]
           ----
           {ar.*,item,EOF}
           .{item.values[1]}
@@ -422,7 +422,7 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{example_file},authorities]
+          [#{extension}2text,#{example_file},authorities]
           ----
           [cols="a,a,a,a",options="header"]
           |===
@@ -495,7 +495,7 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{example_file},my_context]
+          [#{extension}2text,#{example_file},my_context]
           ----
           {% for item in my_context %}
           {% if item.show %}
@@ -540,7 +540,7 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{example_file},my_context]
+          [#{extension}2text,#{example_file},my_context]
           ----
           {{my_context.time}}
 
@@ -572,13 +572,13 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           "time" => Time.gm(2020, 10, 15, 5, 34),
         }
       end
-      let(:parent_file) { "parent_file.#{extention}" }
+      let(:parent_file) { "parent_file.#{extension}" }
       let(:parent_file_content) { [nested_file, nested_file_2] }
-      let(:parent_file_2) { "parent_file_2.#{extention}" }
+      let(:parent_file_2) { "parent_file_2.#{extension}" }
       let(:parent_file_2_content) { ["name", "description"] }
-      let(:parent_file_3) { "parent_file_3.#{extention}" }
+      let(:parent_file_3) { "parent_file_3.#{extension}" }
       let(:parent_file_3_content) { ["one", "two"] }
-      let(:nested_file) { "nested_file.#{extention}" }
+      let(:nested_file) { "nested_file.#{extension}" }
       let(:nested_file_content) do
         {
           "name" => "nested file-main",
@@ -587,7 +587,7 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           "two" => "nested two-main",
         }
       end
-      let(:nested_file_2) { "nested_file_2.#{extention}" }
+      let(:nested_file_2) { "nested_file_2.#{extension}" }
       let(:nested_file_2_content) do
         {
           "name" => "nested2 name-main",
@@ -606,15 +606,15 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           :no-isobib:
           :imagesdir: spec/assets
 
-          [#{extention}2text,#{parent_file},paths]
+          [#{extension}2text,#{parent_file},paths]
           ----
           {% for path in paths %}
 
-          [#{extention}2text,#{parent_file_2},attribute_names]
+          [#{extension}2text,#{parent_file_2},attribute_names]
           ---
           {% for name in attribute_names %}
 
-          [#{extention}2text,{{ path }},data]
+          [#{extension}2text,{{ path }},data]
           --
 
           == {{ data[name] | split: "-" | last }}: {{ data[name] }}
@@ -624,11 +624,11 @@ RSpec.shared_examples "structured data 2 text preprocessor" do
           {% endfor %}
           ---
 
-          [#{extention}2text,#{parent_file_3},attribute_names]
+          [#{extension}2text,#{parent_file_3},attribute_names]
           ---
           {% for name in attribute_names %}
 
-          [#{extention}2text,{{ path }},data]
+          [#{extension}2text,{{ path }},data]
           --
 
           == {{ data[name] }}

--- a/test.asciidoc.log.txt
+++ b/test.asciidoc.log.txt
@@ -1,0 +1,20 @@
+= Document title
+Author
+:docfile: test.adoc
+:nodoc:
+:novalid:
+:no-isobib:
+:imagesdir: spec/assets
+
+=== Nicaragua
+
+Amateur stations:: O[F-J][:digit:][0-9A-Z]{3}[:upper:]{1}
+
+
+
+
+=== Niger
+
+Amateur stations:: O[F-J][:upper:]{5,10}
+
+Experimental:: {"regex"=>"O[F-J][:upper:]{5,10}"}


### PR DESCRIPTION
## Summary

- Fix `extention` → `extension` typo across shared examples and specs
- Fix Content module method naming collision: rename format-detecting method to `load_file_content`, keeping `content_from_file` as the template method in base class
- Make `Json2TextPreprocessor` explicit about JSON-only loading (was silently accepting YAML via inherited format-detection)
- Make `Data2TextPreprocessor` explicit about multi-format loading
- Replace `Array#include?` with `Set` for O(1) nested mark lookup
- Replace fragile `data_file_type` string split with constant `NESTED_CONTEXT_SUFFIX` mapping
- Fix `transform_line_liquid` to use consistent functional style (no mixed `gsub!`/`gsub` mutation)
- Add guard in `values` filter for non-Hash objects
- Remove excessive example comments from preprocessor files
- Clean up spec_helper.rb extension reordering