### PR TITLE
rake.yml: drop hand-edited permissions block; rely on cimas template: https://github.com/metanorma/metanorma-plugin-datastruct/issues/72

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -2,9 +2,6 @@
 # See https://github.com/metanorma/cimas
 name: rake
 
-permissions:
-  contents: read
-
 on:
   push:
     branches: [ master, main ]


### PR DESCRIPTION
## Summary

Per https://github.com/metanorma/metanorma-plugin-datastruct/issues/72, removes the manually-added `permissions: contents: read` block from [.github/workflows/rake.yml](.github/workflows/rake.yml). The file is auto-generated by `cimas` (its header says "Do not edit it manually!") and the explicit-permissions intent now lives in the cimas template per https://github.com/metanorma/cimas/pull/41, so the per-repo hand-edit is no longer needed.

After this PR and the two upstream PRs land, `cimas` regeneration produces this exact file with no diff.

## ⚠️ Do not merge until https://github.com/metanorma/ci/pull/277 lands

While `metanorma/ci/.github/workflows/generic-rake.yml@main` still declares `permissions: contents: write` on the nested `tests-passed` job, removing the caller's explicit `contents: read` means the workflow's validity depends on this repo's default `GITHUB_TOKEN` permissions, which may or may not include `write`. Once metanorma/ci#277 lands, the nested job no longer demands `contents: write`, and this PR becomes safe under any default.

## Dependency chain

1. https://github.com/metanorma/ci/pull/277 — revert the auth-model change in `generic-rake.yml` (required first).
2. https://github.com/metanorma/cimas/pull/41 — add `permissions: contents: read` to the rake template (independent; can land in either order with this PR).
3. This PR — drop the local hand-edit.

## Test plan

- [ ] Wait for https://github.com/metanorma/ci/pull/277 to merge.
- [ ] Re-run the rake workflow on this branch via the GitHub UI; confirm static validation passes and the `rake` matrix runs to completion.
- [ ] After https://github.com/metanorma/cimas/pull/41 also merges, run `cimas` against this repo and confirm `.github/workflows/rake.yml` regenerates byte-for-byte identical to `main` (i.e. with the `permissions: contents: read` block re-added by the template — no hand-edit needed).

cc @ronaldtse
